### PR TITLE
Add weather billboard demo

### DIFF
--- a/billboard_weather.css
+++ b/billboard_weather.css
@@ -1,0 +1,41 @@
+body {
+    margin: 0;
+    padding: 0;
+    font-family: Arial, sans-serif;
+    height: 100vh;
+    overflow: hidden;
+    perspective: 800px;
+    background: linear-gradient(#87CEEB, #E0FFFF);
+}
+
+.cityscape {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background:
+        linear-gradient(#ccc, #999) 0 80% / 20% 20% repeat-x,
+        linear-gradient(#aaa, #777) 10% 85% / 15% 15% repeat-x,
+        linear-gradient(#bbb, #888) 20% 90% / 25% 25% repeat-x;
+}
+
+.billboard {
+    position: absolute;
+    bottom: 30%;
+    left: 50%;
+    transform: translateX(-50%) rotateX(15deg);
+    width: 60%;
+    height: 30%;
+    background: #222;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    box-shadow: 0 10px 20px rgba(0,0,0,0.5);
+    border: 4px solid #555;
+}
+
+#billboard-text {
+    padding: 10px;
+    text-align: center;
+}

--- a/billboard_weather.html
+++ b/billboard_weather.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Weather Billboards</title>
+    <link rel="stylesheet" href="billboard_weather.css">
+</head>
+<body>
+    <div class="cityscape">
+        <div class="billboard">
+            <div id="billboard-text">Loading weather...</div>
+        </div>
+    </div>
+    <script src="billboard_weather.js"></script>
+</body>
+</html>

--- a/billboard_weather.js
+++ b/billboard_weather.js
@@ -1,0 +1,42 @@
+window.addEventListener('DOMContentLoaded', function() {
+    const billboard = document.getElementById('billboard-text');
+
+    const url = 'https://api.open-meteo.com/v1/forecast?latitude=40.7128&longitude=-74.0060&daily=weathercode,temperature_2m_max,temperature_2m_min&timezone=auto';
+
+    fetch(url)
+        .then(r => r.json())
+        .then(data => {
+            const code = data.daily.weathercode[0];
+            const tMin = Math.round(data.daily.temperature_2m_min[0]);
+            const tMax = Math.round(data.daily.temperature_2m_max[0]);
+            const desc = codeToDescription(code);
+            billboard.textContent = `${desc}, ${tMin}\u00B0C - ${tMax}\u00B0C`;
+        })
+        .catch(err => {
+            console.error(err);
+            billboard.textContent = 'Weather unavailable';
+        });
+
+    function codeToDescription(code) {
+        const map = {
+            0: 'Clear sky',
+            1: 'Mainly clear',
+            2: 'Partly cloudy',
+            3: 'Overcast',
+            45: 'Fog',
+            48: 'Rime fog',
+            51: 'Light drizzle',
+            53: 'Drizzle',
+            55: 'Dense drizzle',
+            56: 'Freezing drizzle',
+            57: 'Freezing drizzle',
+            61: 'Slight rain',
+            63: 'Rain',
+            65: 'Heavy rain',
+            71: 'Snow fall',
+            80: 'Rain showers',
+            95: 'Thunderstorm'
+        };
+        return map[code] || 'Weather';
+    }
+});

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <h1>Web Demos</h1>
     <ul>
         <li><a href="door_calculator.html">Door Equal Space Calculator</a> - Calculate equal spacing for different door setups.</li>
+        <li><a href="billboard_weather.html">Weather Billboards</a> - 3D cityscape billboard showing today's forecast.</li>
     </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a cityscape billboard demo that fetches weather
- link new demo from the index page

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684de9cadd2c8327ab467d209faba543