### PR TITLE
Add simple auction tracker page

### DIFF
--- a/auction-data.json
+++ b/auction-data.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "itemName": "Vintage Clock",
+    "currentBid": 50,
+    "endTime": "2024-07-01T12:00:00Z"
+  },
+  {
+    "id": 2,
+    "itemName": "Antique Vase",
+    "currentBid": 75,
+    "endTime": "2024-06-30T18:00:00Z"
+  }
+]

--- a/auction.html
+++ b/auction.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Auction Tracker</title>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; background: #fafafa; }
+        h1 { text-align: center; }
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+        th { background: #eee; }
+    </style>
+</head>
+<body>
+    <h1>Live Auction</h1>
+    <table id="auctionTable">
+        <thead>
+            <tr>
+                <th>Item</th>
+                <th>Current Bid</th>
+                <th>Time Left</th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- Items populated by JavaScript -->
+        </tbody>
+    </table>
+<script>
+async function fetchAuctions() {
+    try {
+        const res = await fetch('auction-data.json');
+        const data = await res.json();
+        const tbody = document.querySelector('#auctionTable tbody');
+        tbody.innerHTML = '';
+        data.forEach(item => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${item.itemName}</td>
+                <td>$<span class="bid">${item.currentBid}</span></td>
+                <td><span class="timer" data-end="${item.endTime}"></span></td>`;
+            tbody.appendChild(tr);
+        });
+        updateTimers();
+    } catch (e) {
+        console.error('Failed to load auction data', e);
+    }
+}
+
+function updateTimers() {
+    const timers = document.querySelectorAll('.timer');
+    timers.forEach(t => {
+        const end = new Date(t.dataset.end);
+        const now = new Date();
+        let diff = end - now;
+        if (diff < 0) diff = 0;
+        const hrs = Math.floor(diff / 36e5).toString().padStart(2, '0');
+        const mins = Math.floor(diff % 36e5 / 6e4).toString().padStart(2, '0');
+        const secs = Math.floor(diff % 6e4 / 1000).toString().padStart(2, '0');
+        t.textContent = `${hrs}:${mins}:${secs}`;
+    });
+}
+
+fetchAuctions();
+setInterval(updateTimers, 1000);
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
 </head>
 <body>
     <h1>Web Demos</h1>
-    <p>No demos are currently available.</p>
+    <ul>
+        <li><a href="auction.html">Auction Tracker</a></li>
+    </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `auction.html` with JS countdown logic
- provide sample data in `auction-data.json`
- link to the auction tracker from `index.html`

## Testing
- `python3 -m http.server --bind 127.0.0.1 8000`

------
https://chatgpt.com/codex/tasks/task_e_684e524bdb288327a321629af41d0db1