### PR TITLE
Add bid monitor script and workflow

### DIFF
--- a/.github/workflows/update-monitor.yml
+++ b/.github/workflows/update-monitor.yml
@@ -1,0 +1,40 @@
+name: Update Bid Monitor
+
+on:
+  schedule:
+    - cron:  '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "\U0001F4E5 Check out repo"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: "\U0001F40D Set up Python"
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: "\U0001F4E6 Install deps"
+        run: |
+          pip install requests beautifulsoup4
+
+      - name: "\U0001F680 Generate monitor page"
+        run: python build_monitor.py
+
+      - name: "\U0001F527 Commit & push if changed"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/index.html
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: update bid monitor"
+            git push
+          else
+            echo "No changes to docs/index.html"
+          fi

--- a/build_monitor.py
+++ b/build_monitor.py
@@ -1,0 +1,68 @@
+import requests
+from bs4 import BeautifulSoup
+
+# URL of your "Active Bids" page
+URL = "https://bidbelowretail.com/Account/Bidding/Active"
+
+# Path where we'll write our GitHub Pages–friendly HTML
+OUT_PATH = "docs/index.html"
+
+def fetch_listings(url):
+    r = requests.get(url)
+    r.raise_for_status()
+    soup = BeautifulSoup(r.text, "html.parser")
+
+    listings = []
+    for card in soup.find_all(attrs={"data-listingid": True}):
+        lid = card["data-listingid"]
+        title_el = card.select_one(".bid-conf-title")
+        curr_el  = card.select_one(".awe-rt-CurrentPrice .NumberPart")
+        min_el   = card.select_one(".awe-rt-MinimumBid .NumberPart")
+        max_el   = card.select_one(".awe-rt-MaxBid .NumberPart")
+        status_el = card.select_one(".awe-rt-CurrentPrice")
+        status = "Winning" if "winning" in status_el.get("class", []) else "Outbid"
+
+        listings.append({
+            "id":    lid,
+            "title": title_el.get_text(strip=True) if title_el else "",
+            "current_price": curr_el.get_text(strip=True) if curr_el else "",
+            "min_bid":       min_el.get_text(strip=True) if min_el else "",
+            "max_bid":       max_el.get_text(strip=True) if max_el else "",
+            "status": status
+        })
+    return listings
+
+def build_html(listings, out_file=OUT_PATH):
+    html = [
+        "<!DOCTYPE html>",
+        "<html><head><meta charset='utf-8'><title>Bid Monitor</title>",
+        "<meta http-equiv='refresh' content='300'>",
+        "<style>table{border-collapse:collapse;}td,th{border:1px solid #444;padding:4px;}</style>",
+        "</head><body>",
+        "<h1>My Active Bids</h1>",
+        "<table>",
+        "<tr><th>ID</th><th>Title</th><th>Current</th><th>Min Bid</th><th>Max Bid</th><th>Status</th></tr>"
+    ]
+    for l in listings:
+        html.append(
+            "<tr>" +
+            f"<td>{l['id']}</td>" +
+            f"<td>{l['title']}</td>" +
+            f"<td>{l['current_price']}</td>" +
+            f"<td>{l['min_bid']}</td>" +
+            f"<td>{l['max_bid']}</td>" +
+            f"<td>{l['status']}</td>" +
+            "</tr>"
+        )
+    html.extend(["</table>", "</body></html>"])
+
+    import os
+    os.makedirs(os.path.dirname(out_file), exist_ok=True)
+
+    with open(out_file, "w", encoding="utf-8") as f:
+        f.write("\n".join(html))
+    print(f"Wrote monitor to {out_file}")
+
+if __name__ == "__main__":
+    data = fetch_listings(URL)
+    build_html(data)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html><head><meta charset='utf-8'><title>Bid Monitor</title></head>
+<body>
+<p>Initial placeholder page.</p>
+</body></html>


### PR DESCRIPTION
## Summary
- add Python script to fetch bid data and generate `docs/index.html`
- create GitHub Actions workflow to update monitor on a schedule
- include placeholder docs page

## Testing
- `python build_monitor.py` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684e59e03c988327bb3c0b199eb61933