### PR TITLE
Add moon advice page

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <h1>Web Demos</h1>
     <ul>
         <li><a href="auction.html">Auction Tracker</a></li>
-    </ul>
+        <li><a href="moon.html">Moon Advice</a></li>
+</ul>
 </body>
 </html>

--- a/moon.html
+++ b/moon.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Moon Advice</title>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700;400&display=swap" rel="stylesheet">
+<style>
+html, body {
+  margin: 0; padding: 0; height: 100%;
+}
+body {
+  min-height: 100vh;
+  width: 100vw;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #f7fafc;
+  text-align: center;
+  font-family: 'Montserrat', Arial, Helvetica, sans-serif;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(to bottom, #0b1c3a 60%, #001324 100%);
+}
+
+svg {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: -2;
+  display: block;
+  pointer-events: none;
+}
+
+.content {
+  position: relative;
+  padding: 2.7rem 2rem 2rem 2rem;
+  background: rgba(18, 33, 66, 0.68);
+  border-radius: 26px;
+  box-shadow: 0 4px 32px 0 rgba(0,20,60,0.22), 0 0 34px #3af4ff17;
+  max-width: 410px;
+  min-width: 288px;
+  backdrop-filter: blur(4.5px);
+  animation: fadeInUp 1.2s cubic-bezier(.22,1,.36,1) both;
+}
+
+@keyframes fadeInUp {
+  from { opacity: 0; transform: translateY(54px);}
+  to { opacity: 1; transform: translateY(0);}
+}
+
+.title-main {
+  font-weight: 700;
+  font-size: 2.2rem;
+  margin-bottom: 0.18em;
+  color: #fff;
+  text-shadow: 0 0 14px #b0e3ff, 0 0 7px #002;
+  letter-spacing: 1.1px;
+  display: inline-block;
+}
+.title-sub {
+  display: block;
+  font-size: 1rem;
+  color: #b7e7f7;
+  margin-bottom: .7em;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  font-weight: 400;
+  opacity: 0.86;
+  transform: translateY(-7px) scale(0.95);
+}
+
+.advice-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2em;
+  margin: 0; padding: 0;
+  align-items: stretch;
+}
+
+.advice-item {
+  background: rgba(36, 49, 92, 0.85);
+  border-radius: 14px;
+  box-shadow: 0 2px 24px #2fd1ed19, 0 1px 0 #001a;
+  padding: 1.05em 1em 1.05em 1em;
+  font-size: 1.18rem;
+  font-weight: 600;
+  color: #fff8ee;
+  text-shadow: 0 2px 12px #171f2f49, 0 0 2px #fff2;
+  position: relative;
+  letter-spacing: 0.03em;
+  line-height: 1.6;
+  transition: box-shadow .3s;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: .7em;
+  animation: itemFadeIn 1.2s cubic-bezier(.7,.06,.4,1) both;
+  border: 1px solid rgba(95,228,255,0.07);
+}
+.advice-item:nth-child(1){animation-delay:.2s;}
+.advice-item:nth-child(2){animation-delay:.5s;}
+.advice-item:nth-child(3){animation-delay:.8s;}
+.advice-item:nth-child(4){animation-delay:1.1s;}
+.advice-item:nth-child(5){animation-delay:1.4s;}
+.advice-icon {
+  font-size: 1.5em;
+  filter: drop-shadow(0 1px 4px #3af3ff70);
+  opacity: 0.93;
+  flex-shrink: 0;
+}
+@keyframes itemFadeIn {
+  from { opacity: 0; transform: translateY(32px);}
+  to { opacity: 1; transform: translateY(0);}
+}
+
+@media (max-width: 500px) {
+  .content { padding: 1.2rem; font-size: 0.99rem; }
+  .title-main { font-size: 1.26rem;}
+  .advice-item { font-size: 1.03rem;}
+}
+
+.star {
+  animation: twinkle 2s infinite;
+  opacity: .8;
+}
+@keyframes twinkle {
+  0%,100% { opacity: 0.9; }
+  50% { opacity: 0.3; }
+}
+.cloud {
+  animation: drift 90s linear infinite;
+  opacity: 0.14;
+}
+.cloud:nth-child(1) { animation-duration: 75s; top: 8%; left: -30vw; }
+.cloud:nth-child(2) { animation-duration: 95s; top: 20%; left: -40vw; opacity: .09;}
+.cloud:nth-child(3) { animation-duration: 110s; top: 13%; left: -60vw; opacity: .13;}
+@keyframes drift {
+  0% { transform: translateX(0);}
+  100% { transform: translateX(180vw);}
+}
+</style>
+</head>
+<body>
+<!-- Magical Night SVG BG -->
+<svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice">
+    <defs>
+        <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#0b1c3a" />
+            <stop offset="100%" stop-color="#001324" />
+        </linearGradient>
+        <radialGradient id="moon" cx="0.5" cy="0.4" r="0.28">
+            <stop offset="0%" stop-color="#fff" stop-opacity="1"/>
+            <stop offset="65%" stop-color="#fffbe5" stop-opacity="0.9"/>
+            <stop offset="100%" stop-color="#fffae8" stop-opacity="0.2"/>
+        </radialGradient>
+        <linearGradient id="water" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stop-color="#013" />
+            <stop offset="100%" stop-color="#001a33" />
+        </linearGradient>
+    </defs>
+    <rect x="0" y="0" width="100" height="65" fill="url(#sky)" />
+    <rect x="0" y="65" width="100" height="35" fill="url(#water)" />
+    <polygon points="0,65 18,54 34,59 50,50 67,59 84,52 100,58 100,65" fill="#162b44" />
+    <circle cx="50" cy="38" r="15" fill="url(#moon)" />
+    <ellipse cx="50" cy="76" rx="17" ry="4.5" fill="rgba(255,255,230,0.25)" />
+    <ellipse cx="50" cy="79" rx="12" ry="2.5" fill="rgba(255,255,230,0.18)" />
+    <ellipse cx="50" cy="81" rx="7" ry="1.4" fill="rgba(255,255,230,0.13)" />
+    <path d="M35,76 Q50,79 65,76" stroke="rgba(255,255,230,0.12)" stroke-width="1" fill="none"/>
+    <path d="M43,78 Q50,80 57,78" stroke="rgba(255,255,230,0.08)" stroke-width="0.7" fill="none"/>
+    <g>
+      <circle class="star" cx="10" cy="10" r="0.5" fill="#fff" />
+      <circle class="star" cx="23" cy="12" r="0.33" fill="#fff" />
+      <circle class="star" cx="18" cy="26" r="0.47" fill="#fff" />
+      <circle class="star" cx="44" cy="6" r="0.32" fill="#fff" />
+      <circle class="star" cx="59" cy="13" r="0.58" fill="#fff" />
+      <circle class="star" cx="82" cy="20" r="0.41" fill="#fff" />
+      <circle class="star" cx="79" cy="5" r="0.31" fill="#fff" />
+      <circle class="star" cx="62" cy="25" r="0.44" fill="#fff" />
+      <circle class="star" cx="91" cy="28" r="0.22" fill="#fff" />
+      <circle class="star" cx="56" cy="31" r="0.30" fill="#fff" />
+      <circle class="star" cx="72" cy="17" r="0.30" fill="#fff" />
+      <circle class="star" cx="34" cy="17" r="0.23" fill="#fff" />
+    </g>
+</svg>
+<svg class="cloud" width="200" height="40" style="position:absolute;top:8%;left:-30vw;z-index:-1;" viewBox="0 0 200 40">
+  <ellipse cx="60" cy="25" rx="50" ry="13" fill="#fff"/>
+  <ellipse cx="130" cy="23" rx="40" ry="12" fill="#fff"/>
+</svg>
+<svg class="cloud" width="120" height="36" style="position:absolute;top:20%;left:-40vw;z-index:-1;" viewBox="0 0 120 36">
+  <ellipse cx="60" cy="18" rx="48" ry="10" fill="#fff"/>
+  <ellipse cx="90" cy="16" rx="20" ry="7" fill="#fff"/>
+</svg>
+<svg class="cloud" width="160" height="33" style="position:absolute;top:13%;left:-60vw;z-index:-1;" viewBox="0 0 160 33">
+  <ellipse cx="80" cy="16" rx="60" ry="9" fill="#fff"/>
+  <ellipse cx="120" cy="13" rx="30" ry="7" fill="#fff"/>
+</svg>
+
+<div class="content">
+  <span class="title-sub">from the</span>
+  <span class="title-main">Moon</span>
+  <div class="advice-list">
+    <div class="advice-item"><span class="advice-icon">🌕</span>Live life to the fullest.</div>
+    <div class="advice-item"><span class="advice-icon">🔭</span>Be someone to look up to.</div>
+    <div class="advice-item"><span class="advice-icon">🌑</span>Don’t be phased by difficulties.</div>
+    <div class="advice-item"><span class="advice-icon">🌊</span>Take time to reflect.</div>
+    <div class="advice-item"><span class="advice-icon">✨</span>Light up the night.</div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add interactive moon advice page with CSS animations
- link new page from site index

## Testing
- `python build_monitor.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684f3faaa11483279722ed2caa349090