### PR TITLE
Add service worker for offline caching

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,32 @@
+const CACHE = 'inch-calc-v1'; // increment to refresh cache
+
+// List of local resources we always want cached
+const ASSETS = [
+  '/',
+  '/tapemeasurememory.html',
+  '/manifest.webmanifest',
+  '/icon-192.png',
+  '/icon-512.png',
+  '/styles.css',
+  '/script.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE).map(key => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add `sw.js` with versioned cache
- precache core assets and handle install, activate and fetch events

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b13c3a197c832787cfd737df723ae4