### PR TITLE
feat: update service worker

### DIFF
--- a/calc_screens.html
+++ b/calc_screens.html
@@ -1392,14 +1392,15 @@
 
 <!-- ===== sw.js (create this file alongside) ===== -->
 <!--
-const CACHE_NAME = 'inch-calc-v1-2025-08-23';
+const CACHE_NAME = 'inch-calc-v2';
 const ASSETS = [
   './',
-  './tapemeasurememory.html',
+  './calc_screens.html',
   './manifest.webmanifest',
   './sw.js',
-  './calcicon.png',
-  './apple-touch-icon.png'
+  './calcicon-192.png',
+  './calcicon-512.png',
+  './maskable-512.png'
 ];
 
 self.addEventListener('install', (event) => {

--- a/sw.js
+++ b/sw.js
@@ -1,32 +1,72 @@
-const CACHE = 'inch-calc-v1'; // increment to refresh cache
-
-// List of local resources we always want cached
+const CACHE_NAME = 'inch-calc-v2';
 const ASSETS = [
-  '/',
-  '/tapemeasurememory.html',
-  '/manifest.webmanifest',
-  '/icon-192.png',
-  '/icon-512.png',
-  '/styles.css',
-  '/script.js'
+  './',
+  './calc_screens.html',
+  './manifest.webmanifest',
+  './sw.js',
+  './calcicon-192.png',
+  './calcicon-512.png',
+  './maskable-512.png'
 ];
 
-self.addEventListener('install', event => {
+self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE).then(cache => cache.addAll(ASSETS))
+    caches.open(CACHE_NAME)
+      .then((cache) => cache.addAll(ASSETS))
+      .then(() => self.skipWaiting())
   );
 });
 
-self.addEventListener('activate', event => {
+self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.filter(key => key !== CACHE).map(key => caches.delete(key)))
-    )
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+    )).then(() => self.clients.claim())
   );
 });
 
-self.addEventListener('fetch', event => {
+self.addEventListener('fetch', (event) => {
+  const req = event.request;
+  const accept = req.headers.get('accept') || '';
+
+  // HTML (navigation): network-first
+  if (req.mode === 'navigate' || accept.includes('text/html')){
+    event.respondWith(
+      fetch(req)
+        .then((res) => {
+          const copy = res.clone();
+          caches.open(CACHE_NAME).then(c => c.put(req, copy));
+          return res;
+        })
+        .catch(() => caches.match(req))
+    );
+    return;
+  }
+
+  const sameOrigin = new URL(req.url).origin === self.location.origin;
+
+  // Same-origin assets: cache-first
+  if (sameOrigin){
+    event.respondWith(
+      caches.match(req).then((cached) => cached || fetch(req).then((res) => {
+        const copy = res.clone();
+        caches.open(CACHE_NAME).then(c => c.put(req, copy));
+        return res;
+      }))
+    );
+    return;
+  }
+
+  // Cross-origin (e.g., CDN): network, fallback to cache
   event.respondWith(
-    caches.match(event.request).then(response => response || fetch(event.request))
+    fetch(req).then((res) => {
+      const copy = res.clone();
+      caches.open(CACHE_NAME).then(c => c.put(req, copy));
+      return res;
+    }).catch(() => caches.match(req))
   );
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data === 'skipWaiting') self.skipWaiting();
 });


### PR DESCRIPTION
## Summary
- replace service worker with network-first HTML and cache-first asset strategy
- cache new icons, manifest and calc_screens.html; bump cache version to v2
- drop obsolete tapemeasurememory references

## Testing
- `node --check sw.js`
- `node sw_test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b4d3fc399883279346fc38f10c4335